### PR TITLE
Wave equation ssprk2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GridapGeosciences"
 uuid = "77ae386e-bde6-49b0-bd6e-9c07e8aee685"
-authors = [ "Santiago Badia <santiago.badia@monash.edu>", "Christopher Bladwell <c.bladwell@unsw.edu.au>", "David R. Lee <davelee2804@gmail.com >",  "Alberto F. Martin <alberto.martin@monash.edu>"]
+authors = ["Santiago Badia <santiago.badia@monash.edu>", "Christopher Bladwell <c.bladwell@unsw.edu.au>", "David R. Lee <davelee2804@gmail.com >", "Alberto F. Martin <alberto.martin@monash.edu>"]
 version = "0.1.0"
 
 [deps]
@@ -9,6 +9,7 @@ Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 LineSearches = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
 julia = "1.3"

--- a/test/WaveEquationCubedSphereTests.jl
+++ b/test/WaveEquationCubedSphereTests.jl
@@ -1,0 +1,197 @@
+module WaveEquationCubedSphereTests
+
+using Test
+using Gridap
+using GridapGeosciences
+using Plots
+using LinearAlgebra
+using WriteVTK
+
+# Initial depth
+function h₀(xyz)
+  x,y,z = xyz
+  xᵢ,yᵢ,zᵢ = (1,0,0)
+  1.0 + 0.0001*exp(-5*((xᵢ-x)^2+(yᵢ-y)^2+(zᵢ-z)^2))
+end
+
+# Initial velocity
+u₀(xyz) = zero(xyz)
+
+"""
+  Kinetic energy
+"""
+function Eₖ(uh,H,dΩ)
+  0.5*H*sum(∫(uh⋅uh)dΩ)
+end
+
+"""
+  Potential energy
+"""
+function Eₚ(hh,g,dΩ)
+  0.5*g*sum(∫(hh*hh)dΩ)
+end
+
+"""
+  Total energy
+"""
+function Eₜ(uh,H,hh,g,dΩ)
+  Eₖ(uh,H,dΩ)+Eₚ(hh,g,dΩ)
+end
+
+"""
+  Kinetic to potential
+"""
+function compute_kin_to_pot!(w,unv,divvh,hnv)
+  mul!(w,divvh,hnv)
+  unv⋅w
+end
+
+"""
+  Potential to kinetic
+"""
+function compute_pot_to_kin!(w,hnv,qdivu,unv)
+   mul!(w,qdivu,unv)
+   hnv⋅w
+end
+
+
+function new_vtk_step(Ω,file,hn,un)
+  createvtk(Ω,
+            file,
+            cellfields=["hn"=>hn, "un"=>un],
+            nsubcells=4)
+end
+
+function _ssrk2_update!(res,MM,MMchol,DIV,α,a,b)
+  mul!(res, MM, a)            # res <- MM*a
+  mul!(res, DIV, b, α, 1.0)   # res <- 1.0*res + α*DIV*b
+  ldiv!(MMchol,res)           # res <- inv(MM)*res
+end
+
+function generate_energy_plots(outdir,N,ke,pe,kin_to_pot,pot_to_kin)
+  plot(1:N,
+       [ke,pe],
+       label=["Ek (kinetic)" "Ep (potential)"],
+       xlabel="Step",ylabel="Energy")
+  savefig(joinpath(outdir,"energy.png"))
+  plot(1:N,
+       [kin_to_pot,-pot_to_kin,kin_to_pot-pot_to_kin],
+       label=["hⁿ∇⋅uⁿ" "uⁿ⋅∇(hⁿ)" "Balance"],
+       xlabel="Step",ylabel="Kinetic to potential energy balance",legend = :outertopleft)
+  savefig(joinpath(outdir,"kinetic_to_potential_energy_balance.png"))
+end
+
+"""
+  Solves the wave equation using a 2nd order
+  Strong-Stability-Preserving Runge-Kutta
+  explicit time integration scheme (SSRK2)
+
+  g : acceleration due to gravity
+  H : (constant) reference layer depth
+  T : [0,T] simulation interval
+  N : number of time subintervals
+"""
+function solve_wave_equation_ssrk2(
+      model,order,degree,g,H,T,N;
+      write_results=false,
+      out_dir="wave_eq_ncells_$(num_cells(model))_order_$(order)_ssrk2",
+      out_period=N/10)
+
+  RT=ReferenceFE(raviart_thomas,Float64,order)
+  DG=ReferenceFE(lagrangian,Float64,order)
+  V = FESpace(model,RT; conformity=:Hdiv)
+  Q = FESpace(model,DG; conformity=:L2)
+
+  U = TrialFESpace(V)
+  P = TrialFESpace(Q)
+
+  Ω  = Triangulation(model)
+  dΩ = Measure(Ω,degree)
+  dω = Measure(Ω,degree,ReferenceDomain())
+
+  # Build mass matrix in RT and DG spaces
+  # and their sparse Cholesky factors
+  amm(u,v) = ∫(v⋅u)dΩ
+  RTMM=assemble_matrix(amm,U,V)
+  L2MM=assemble_matrix(amm,P,Q)
+  RTMMchol=lu(RTMM)
+  L2MMchol=lu(L2MM)
+
+  # Build g*DIV(v)*h and H*q*DIV(u)
+  ad(h,v) = ∫(DIV(v)*h)dω
+  divvh=assemble_matrix(ad,P,V)
+  adt(u,q) = ∫(q*DIV(u))dω
+  qdivu=assemble_matrix(adt,U,Q)
+
+  # Interpolate initial condition into FE spaces
+  hn=interpolate_everywhere(h₀,P); hnv=get_free_dof_values(hn)
+  un=interpolate_everywhere(u₀,U); unv=get_free_dof_values(un)
+  if (write_results)
+    rm(out_dir,force=true,recursive=true)
+    mkdir(out_dir)
+  end
+  pvdfile=joinpath(out_dir,"wave_eq_ncells_$(num_cells(model))_order_$(order)_ssrk2")
+  paraview_collection(pvdfile) do pvd
+    # Allocate work space vectors
+    h1v = similar(get_free_dof_values(hn))
+    h2v = similar(h1v)
+    u1v = similar(get_free_dof_values(un))
+    u2v = similar(u1v)
+    if (write_results)
+      ke  = Vector{Float64}(undef,N)
+      pe  = Vector{Float64}(undef,N)
+      kin_to_pot = Vector{Float64}(undef,N)
+      pot_to_kin = Vector{Float64}(undef,N)
+    end
+    dt  = T/N
+    dtg = dt*g
+    dtH = dt*H
+    for step=1:N
+       # 1st step
+       # inv(L2MM)*(L2MM*hnv - dt*Hqdivu*unv)
+       # inv(RTMM)*(RTMM*unv + dt*gdivvh*hnv)
+       @time _ssrk2_update!(h1v, L2MM, L2MMchol, qdivu,-dtH, hnv, unv)
+       @time _ssrk2_update!(u1v, RTMM, RTMMchol, divvh, dtg, unv, hnv)
+
+       # 2nd step
+       # inv(L2MM)*(L2MM*h1v - dt*Hqdivu*u1v)
+       # inv(RTMM)*(RTMM*u1v + dt*gdivvh*h1v)
+       @time _ssrk2_update!(h2v, L2MM, L2MMchol, qdivu, -dtH, h1v, u1v)
+       @time _ssrk2_update!(u2v, RTMM, RTMMchol, divvh,  dtg, u1v, h1v)
+
+       # Averaging steps
+       hnv .= 0.5 .* ( hnv .+ h2v )
+       unv .= 0.5 .* ( unv .+ u2v )
+
+       if (write_results)
+         ke[step]=Eₖ(un,H,dΩ)
+         pe[step]=Eₚ(hn,g,dΩ)
+         kin_to_pot[step]=compute_kin_to_pot!(u1v,unv,divvh,hnv)
+         pot_to_kin[step]=compute_pot_to_kin!(h1v,hnv,qdivu,unv)
+         if mod(step, out_period) == 0
+           println(step)
+           pvd[Float64(step)] = new_vtk_step(Ω,joinpath(out_dir,"n=$(step)"),hn,un)
+         end
+       end
+    end
+    if (write_results)
+      pvd[Float64(N)] = new_vtk_step(Ω,joinpath(out_dir,"n=$(N)"),hn,un)
+      vtk_save(pvd)
+      generate_energy_plots(out_dir,N,ke,pe,kin_to_pot,pot_to_kin)
+    end
+  end
+  un,hn
+end
+
+model=CubedSphereDiscreteModel(10)
+g=1.0
+H=1.0
+T=2π
+N=2000
+order=0
+degree=4
+@time un,hn =
+  solve_wave_equation_ssrk2(model,order,degree,g,H,T,N;write_results=true,out_period=10)
+
+
+end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,4 +6,6 @@ using Test
   @time @testset "DarcyCubedSphereTests" begin include("DarcyCubedSphereTests.jl") end
   @time @testset "WeakDivPerpTests" begin include("WeakDivPerpTests.jl") end
   @time @testset "LaplaceBeltramiCubedSphereTests" begin include("LaplaceBeltramiCubedSphereTests.jl") end
+  @time @testset "WaveEquationCubedSphereTests" begin include("WaveEquationCubedSphereTests.jl") end
+  
 end


### PR DESCRIPTION
Hi @cbladwell, @davelee2804,

in this PR I have developed a first implementation (I want to subject it to review from your side) of the SSPRK2 (Strong Stability Preserving explicit Runge Kutta 2nd order) time integration method for the linear wave equation. In this implementation, the time integration vector updates are performed using lower level functions (still of Julia's high level API though) than the ones in your implementation. **The goal is to reduce to the minimum the amount of dynamic memory allocation during the time integration loop.** Please note that I have also tried to maximize the usage of Gridap's high level API. Sure that it can be improved, but this is what I have in mind of a reasonable simulation driver.

I think the implementation is correct. With 10x10 quads/panel (analytical geometrical mapping), T=2*PI, g=H=1, 2000 time steps, RT0-DG0, the potential to kinetic energy balance looks like as in Chris's slides:

![kinetic_to_potential_energy_balance](https://user-images.githubusercontent.com/38347633/130558314-698db22b-4f7a-404d-8270-32b837cc91c7.png)


Please note the following: 
 1. The `assemble_matrix` Gridap's high level API function let us compute a matrix by FE assembly in a single call out of the bilinear form and FE spaces. See [here](https://github.com/gridapapps/GridapGeosciences.jl/blob/3e92f4742fbe4e2129c94ace68cb2c886ad6fcb1/test/WaveEquationCubedSphereTests.jl#L115). There is also an `assemble_vector` counterpart. 
 2. The time integration loop is fully performed using linear algebra data structures (i.e., vectors and matrices). We do not actually need to create `FEFunction` instances along the process. We create them at the beginning, and extract pointers out of them (via `get_free_dof_values`) that we use along the loop. 
 3. The LU factorization of the mass matrices is computed once (see, e.g., [here](https://github.com/gridapapps/GridapGeosciences.jl/blob/3e92f4742fbe4e2129c94ace68cb2c886ad6fcb1/test/WaveEquationCubedSphereTests.jl#L117)) before the time integration loop, and reused over and over again at each iteration of the loop (see, e.g., [here](https://github.com/gridapapps/GridapGeosciences.jl/blob/3e92f4742fbe4e2129c94ace68cb2c886ad6fcb1/test/WaveEquationCubedSphereTests.jl#L68)). If we used `solve` with an `AffineFEOperator` instance (I think) we would be computing the lu factorization at each time step!!!
 4.  The non-diagonal component matrices div(v)*p and q*div(u) are assembled only once at the beginning using reference element integration (see, e.g., [here](https://github.com/gridapapps/GridapGeosciences.jl/blob/3e92f4742fbe4e2129c94ace68cb2c886ad6fcb1/test/WaveEquationCubedSphereTests.jl#L122)) and re-used over and over again at each iteraiton of the loop (see [here](https://github.com/gridapapps/GridapGeosciences.jl/blob/3e92f4742fbe4e2129c94ace68cb2c886ad6fcb1/test/WaveEquationCubedSphereTests.jl#L67))
5. Vector updates that solely involve vectors are performed using dot notation (see, e.g., [here](https://github.com/gridapapps/GridapGeosciences.jl/blob/3e92f4742fbe4e2129c94ace68cb2c886ad6fcb1/test/WaveEquationCubedSphereTests.jl#L163)) so that they are performed with a single vectorized loop and no temporary dynamic memory allocation. (You are already aware of this, we have talk about this before, anyway it worths remarking.)
6. I am using FE interpolation (i.e. evaluation of DoFs) instead of L2 projection to inject the initial condition to the FE space (see, e.g., [here](https://github.com/gridapapps/GridapGeosciences.jl/blob/3e92f4742fbe4e2129c94ace68cb2c886ad6fcb1/test/WaveEquationCubedSphereTests.jl#L127). Note that interpolation is also a valid type of projection in itself.
7. In many places (although not in all places), there is no need to explicitly use the `CellField` constructor with analytical functions,  Gridap calls it under the hood for you.  

Let me know your thoughs about the code. We can discuss it at any moment if you like.
