### PR TITLE
Necessary mods to port repo to Gridap 0.17

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
-Gridap = "0.17"
+Gridap = "0.17.2"
 SparseMatricesCSR = "0.6.2"
 julia = "1.5"
 

--- a/Project.toml
+++ b/Project.toml
@@ -20,9 +20,9 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
 
 [compat]
+Gridap = "0.17"
+SparseMatricesCSR = "0.6.2"
 julia = "1.5"
-SparseMatricesCSR ="0.6.2"
-Gridap = "0.16"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/CubedSphereTriangulations.jl
+++ b/src/CubedSphereTriangulations.jl
@@ -1,52 +1,22 @@
 
 struct AnalyticalMapCubedSphereTriangulation{T} <: Triangulation{2,3}
-  cell_map::T
-  btrian::Triangulation{2,3}
+  cubed_sphere_model::T
 end
 
 # Triangulation API
 
 # Delegating to the underlying face Triangulation
 
-Gridap.Geometry.get_cell_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_coordinates(trian.btrian)
+Gridap.Geometry.get_cell_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_coordinates(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_reffes(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_reffes(trian.btrian)
+Gridap.Geometry.get_reffes(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_reffes(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_cell_type(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_type(trian.btrian)
+Gridap.Geometry.get_cell_type(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_type(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_node_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Helpers.get_node_coordinates(trian.btrian)
+Gridap.Geometry.get_node_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Helpers.get_node_coordinates(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_cell_node_ids(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Helpers.get_cell_node_ids(trian.btrian)
+Gridap.Geometry.get_cell_node_ids(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Helpers.get_cell_node_ids(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_cell_map(trian::AnalyticalMapCubedSphereTriangulation) = trian.cell_map
+Gridap.Geometry.get_cell_map(trian::AnalyticalMapCubedSphereTriangulation) = trian.cubed_sphere_model.cell_map
 
-# Genuine methods
-
-Gridap.Geometry.TriangulationStyle(::Type{<:AnalyticalMapCubedSphereTriangulation}) = SubTriangulation()
-
-Gridap.Geometry.get_background_triangulation(trian::AnalyticalMapCubedSphereTriangulation) =
-      Gridap.Geometry.get_background_triangulation(trian.btrian)
-
-Gridap.Geometry.get_cell_to_bgcell(trian::AnalyticalMapCubedSphereTriangulation) = get_cell_to_bgcell(trian.btrian)
-
-function Gridap.Geometry.get_cell_to_bgcell(
-  trian_in::AnalyticalMapCubedSphereTriangulation,
-  trian_out::AnalyticalMapCubedSphereTriangulation)
-  Gridap.Helpers.@notimplemented
-end
-
-function Gridap.Geometry.is_included(
-  trian_in::AnalyticalMapCubedSphereTriangulation,
-  trian_out::AnalyticalMapCubedSphereTriangulation)
-  Gridap.Helpers.@notimplemented
-end
-
-function Gridap.Geometry.get_cell_ref_map(trian::AnalyticalMapCubedSphereTriangulation)
-  get_cell_ref_map(trian.btrian)
-end
-
-function Gridap.Geometry.get_cell_ref_map(
-  trian_in::AnalyticalMapCubedSphereTriangulation,
-  trian_out::AnalyticalMapCubedSphereTriangulation)
-  Gridap.Helpers.@notimplemented
-end
+Gridap.Geometry.get_grid(trian::AnalyticalMapCubedSphereTriangulation) = get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model)

--- a/src/CubedSphereTriangulations.jl
+++ b/src/CubedSphereTriangulations.jl
@@ -13,9 +13,9 @@ Gridap.Geometry.get_reffes(trian::AnalyticalMapCubedSphereTriangulation) = Grida
 
 Gridap.Geometry.get_cell_type(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_type(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_node_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Helpers.get_node_coordinates(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
+Gridap.Geometry.get_node_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_node_coordinates(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_cell_node_ids(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Helpers.get_cell_node_ids(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
+Gridap.Geometry.get_cell_node_ids(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_node_ids(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
 
 Gridap.Geometry.get_cell_map(trian::AnalyticalMapCubedSphereTriangulation) = trian.cubed_sphere_model.cell_map
 

--- a/src/ShallowWaterThetaMethodFullNewton.jl
+++ b/src/ShallowWaterThetaMethodFullNewton.jl
@@ -97,20 +97,7 @@ function shallow_water_theta_method_full_newton_time_stepper(
          ∫(s*qvort*hiΔh + ⟂(∇(s),n)⋅uiΔu - s*fn +   # eq3
              v2⋅(F-hiΔh*uiΔu))dΩ                      # eq4
        end
-       function jacobian((Δu,Δh,qvort,F),(du,dh,dq,dF),(v,q,s,v2))
-         one_m_θ = (1-θ)
-         uiΔu  = un + one_m_θ*Δu
-         hiΔh  = hn + one_m_θ*Δh
-         uidu  = one_m_θ*du
-         hidh  = one_m_θ*dh
-         ∫((1.0/dt)*v⋅du +  (dq    - τ*(uiΔu⋅∇(dq)+uidu⋅∇(qvort)))*(v⋅⟂(F ,n))
-                         +  (qvort - τ*(           uiΔu⋅∇(qvort)))*(v⋅⟂(dF,n))
-                         -  (∇⋅(v))*(g*hidh +uiΔu⋅uidu)   +  # eq1
-           (1.0/dt)*q*dh)dΩ + ∫(q*(DIV(dF)))dω             +  # eq2
-           ∫(s*(qvort*hidh+dq*hiΔh) + ⟂(∇(s),n)⋅uidu       +  # eq3
-             v2⋅(dF-hiΔh*uidu-hidh*uiΔu))dΩ                   # eq4
-       end
-
+       
        # Solve fully-coupled monolithic nonlinear problem
        # Use previous time-step solution, ΔuΔhqF, as initial guess
        # Overwrite solution into ΔuΔhqF
@@ -120,7 +107,7 @@ function shallow_water_theta_method_full_newton_time_stepper(
        residualΔuΔhqF=residual(ΔuΔhqF,dY)
        r=assemble_vector(residualΔuΔhqF,Y)
        assem = SparseMatrixAssembler(sparse_matrix_type,Vector{Float64},X,Y)
-       op=FEOperator(residual,jacobian,X,Y,assem)
+       op=FEOperator(residual,X,Y,assem)
        nls=NLSolver(linear_solver;
                     show_trace=true,
                     method=:newton,


### PR DESCRIPTION
@davelee2804 @cbladwell @santiagobadia 

In this PR I have performed the necessary changes in GridapGeosciences s.t. it is now compatible with Gridap 0.17. Note that these changes **ONLY** affect to the internals of GridapGeosciences. The user drivers and tests have not been affected by these changes.

Besides, I have removed the hand-written computation of the Jacobian by an AD Jacobian in the Full Newton, implicit trapezoidal rule time stepper. I checked that this reduces the first call latency of  `Williamson2ThetaMethodFullNewtonTests.jl`  on my local machine with Julia 1.5.2 by approx 40% (1592.564583 secs. versus 932.869358 sec.)

@davelee2804 ... is it ok if we merge these changes into `master`? Does these changes affect in any way your current ongoing developments with GridapGeosciences?