### PR TITLE
get_normal_vector is now a method of triangulation

### DIFF
--- a/src/CubedSphereTriangulations.jl
+++ b/src/CubedSphereTriangulations.jl
@@ -1,22 +1,70 @@
 
-struct AnalyticalMapCubedSphereTriangulation{T} <: Triangulation{2,3}
-  cubed_sphere_model::T
+struct PolynomialMapCubedSphereTriangulation{T} <: Triangulation{2,3}
+  model::T
 end
 
+Gridap.Geometry.get_cell_coordinates(trian::PolynomialMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_coordinates(get_grid(trian.model))
+
+Gridap.Geometry.get_reffes(trian::PolynomialMapCubedSphereTriangulation) = Gridap.Geometry.get_reffes(get_grid(trian.model))
+
+Gridap.Geometry.get_cell_type(trian::PolynomialMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_type(get_grid(trian.model))
+
+Gridap.Geometry.get_node_coordinates(trian::PolynomialMapCubedSphereTriangulation) = Gridap.Geometry.get_node_coordinates(get_grid(trian.model))
+
+Gridap.Geometry.get_cell_node_ids(trian::PolynomialMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_node_ids(get_grid(trian.model))
+
+Gridap.Geometry.get_cell_map(trian::PolynomialMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_map(trian.model)
+
+Gridap.Geometry.get_grid(trian::PolynomialMapCubedSphereTriangulation) = Gridap.Geometry.get_grid(trian.model)
+
+
+struct AnalyticalMapCubedSphereTriangulation{T} <: Triangulation{2,3}
+  model::T
+end
+
+const CSDTT = Union{PolynomialMapCubedSphereTriangulation,AnalyticalMapCubedSphereTriangulation}
+
 # Triangulation API
+function Gridap.Geometry.get_facet_normal(trian::CSDTT)
+  function _unit_outward_normal(v::Gridap.Fields.MultiValue{Tuple{2,3}},sign_flip::Bool)
+    n1 = v[1,2]*v[2,3] - v[1,3]*v[2,2]
+    n2 = v[1,3]*v[2,1] - v[1,1]*v[2,3]
+    n3 = v[1,1]*v[2,2] - v[1,2]*v[2,1]
+    n = VectorValue(n1,n2,n3)
+    (-1)^sign_flip*n/norm(n)
+  end
+
+  # Get the Jacobian of the cubed sphere mesh
+  map   = get_cell_map(trian)
+  Jt    = lazy_map(∇,map)
+
+  # Get the index of the panel for each element
+  fl = get_face_labeling(trian.model)
+  panel_id  = fl.d_to_dface_to_entity[3]
+  sign_flip = [panel_id[i] == 25 || panel_id[i] == 21 || panel_id[i] == 24 for i=1:length(panel_id)]
+  fsign_flip = lazy_map(Gridap.Fields.ConstantField,sign_flip)
+
+  lazy_map(Operation(_unit_outward_normal),Jt,fsign_flip)
+end
+
+function Gridap.CellData.get_normal_vector(trian::CSDTT)
+  cell_normal = Gridap.Geometry.get_facet_normal(trian)
+  Gridap.CellData.GenericCellField(cell_normal,trian,ReferenceDomain())
+end
+
 
 # Delegating to the underlying face Triangulation
 
-Gridap.Geometry.get_cell_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_coordinates(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
+Gridap.Geometry.get_cell_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_coordinates(get_grid(trian.model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_reffes(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_reffes(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
+Gridap.Geometry.get_reffes(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_reffes(get_grid(trian.model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_cell_type(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_type(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
+Gridap.Geometry.get_cell_type(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_type(get_grid(trian.model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_node_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_node_coordinates(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
+Gridap.Geometry.get_node_coordinates(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_node_coordinates(get_grid(trian.model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_cell_node_ids(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_node_ids(get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model))
+Gridap.Geometry.get_cell_node_ids(trian::AnalyticalMapCubedSphereTriangulation) = Gridap.Geometry.get_cell_node_ids(get_grid(trian.model.cubed_sphere_linear_model))
 
-Gridap.Geometry.get_cell_map(trian::AnalyticalMapCubedSphereTriangulation) = trian.cubed_sphere_model.cell_map
+Gridap.Geometry.get_cell_map(trian::AnalyticalMapCubedSphereTriangulation) = trian.model.cell_map
 
-Gridap.Geometry.get_grid(trian::AnalyticalMapCubedSphereTriangulation) = get_grid(trian.cubed_sphere_model.cubed_sphere_linear_model)
+Gridap.Geometry.get_grid(trian::AnalyticalMapCubedSphereTriangulation) = get_grid(trian.model.cubed_sphere_linear_model)

--- a/src/ShallowWaterExplicit.jl
+++ b/src/ShallowWaterExplicit.jl
@@ -156,7 +156,7 @@ function shallow_water_explicit_time_stepper(model, order, degree,
     end
 
     if (write_diagnostics && write_diagnostics_freq==1)
-      compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+      compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
       dump_diagnostics_shallow_water!(h_tmp, w_tmp,
                                       model, dΩ, dω, S, L2MM, H1MM,
                                       hn, un, wn, ϕ, F, g, 1, dt,
@@ -181,7 +181,7 @@ function shallow_water_explicit_time_stepper(model, order, degree,
                                         RTMMchol, L2MMchol, dt, τ, true)
 
       if (write_diagnostics && write_diagnostics_freq>0 && mod(istep, write_diagnostics_freq) == 0)
-        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
         dump_diagnostics_shallow_water!(h_tmp, w_tmp,
                                         model, dΩ, dω, S, L2MM, H1MM,
                                         hn, un, wn, ϕ, F, g, istep, dt,
@@ -189,7 +189,7 @@ function shallow_water_explicit_time_stepper(model, order, degree,
                                         dump_diagnostics_on_screen)
       end
       if (write_solution && write_solution_freq>0 && mod(istep, write_solution_freq) == 0)
-        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
         pvd[dt*Float64(istep)] = new_vtk_step(Ω,joinpath(output_dir,"n=$(istep)"),["hn"=>hn,"un"=>un,"wn"=>wn])
       end
     end

--- a/src/ShallowWaterExplicit.jl
+++ b/src/ShallowWaterExplicit.jl
@@ -45,7 +45,7 @@ function shallow_water_explicit_time_step!(
   # reference: eqns (21-24) of
   # https://github.com/BOM-Monash-Collaborations/articles/blob/main/energetically_balanced_time_integration/EnergeticallyBalancedTimeIntegration_SW.tex
 
-  n = get_normal_vector(model)
+  n = get_normal_vector(Triangulation(model))
   # explicit step for provisional velocity, uₚ
   dt1 = dt
   if leap_frog
@@ -118,7 +118,7 @@ function shallow_water_explicit_time_stepper(model, order, degree,
   H1MM, _, L2MM, H1MMchol, RTMMchol, L2MMchol = setup_and_factorize_mass_matrices(dΩ, R, S, U, V, P, Q)
 
   # Project the initial conditions onto the trial spaces
-  hn, un, f, hnv, unv, fv =  project_shallow_water_initial_conditions(dΩ, Q, V, S, 
+  hn, un, f, hnv, unv, fv =  project_shallow_water_initial_conditions(dΩ, Q, V, S,
                                L2MMchol, RTMMchol, H1MMchol, h₀, u₀, f₀)
 
   # work arrays

--- a/src/ShallowWaterIMEX.jl
+++ b/src/ShallowWaterIMEX.jl
@@ -89,7 +89,7 @@ function shallow_water_imex_time_step!(
   # reference: eqns (31-33) of
   # https://github.com/BOM-Monash-Collaborations/articles/blob/main/energetically_balanced_time_integration/EnergeticallyBalancedTimeIntegration_SW.tex
 
-  n = get_normal_vector(model)
+  n = get_normal_vector(Triangulation(model))
   # explicit step for provisional velocity, uₚ
   dt1 = dt
   if leap_frog
@@ -158,7 +158,7 @@ function shallow_water_imex_time_stepper(model, order, degree,
       setup_and_factorize_mass_matrices(dΩ, R, S, U, V, P, Q)
 
   # Project the initial conditions onto the trial spaces
-  hn, un, f, hnv, unv, fv =  project_shallow_water_initial_conditions(dΩ, Q, V, S, 
+  hn, un, f, hnv, unv, fv =  project_shallow_water_initial_conditions(dΩ, Q, V, S,
                                L2MMchol, RTMMchol, H1MMchol, h₀, u₀, f₀)
 
   # work arrays

--- a/src/ShallowWaterIMEX.jl
+++ b/src/ShallowWaterIMEX.jl
@@ -204,7 +204,7 @@ function shallow_water_imex_time_stepper(model, order, degree,
     end
 
     if (write_diagnostics && write_diagnostics_freq==1)
-      compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+      compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
       dump_diagnostics_shallow_water!(h_tmp, w_tmp,
                                       model, dΩ, dω, S, L2MM, H1MM,
                                       hn, un, wn, ϕ, F, g, 1, dt,
@@ -229,7 +229,7 @@ function shallow_water_imex_time_stepper(model, order, degree,
                                     RTMMchol, L2MMchol, RTMM, invL2MMD, dt, τ, true)
 
       if (write_diagnostics && write_diagnostics_freq>0 && mod(istep, write_diagnostics_freq) == 0)
-        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
         dump_diagnostics_shallow_water!(h_tmp, w_tmp,
                                         model, dΩ, dω, S, L2MM, H1MM,
                                         hn, un, wn, ϕ, F, g, istep, dt,
@@ -237,7 +237,7 @@ function shallow_water_imex_time_stepper(model, order, degree,
                                         dump_diagnostics_on_screen)
       end
       if (write_solution && write_solution_freq>0 && mod(istep, write_solution_freq) == 0)
-        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
         pvd[dt*Float64(istep)] = new_vtk_step(Ω,joinpath(output_dir,"n=$(istep)"),["hn"=>hn,"un"=>un,"wn"=>wn])
       end
     end

--- a/src/ShallowWaterRosenbrock.jl
+++ b/src/ShallowWaterRosenbrock.jl
@@ -14,7 +14,7 @@ function shallow_water_rosenbrock_time_step!(
   # reference: eqns (24) and (39) of
   # https://github.com/BOM-Monash-Collaborations/articles/blob/main/energetically_balanced_time_integration/EnergeticallyBalancedTimeIntegration_SW.tex
 
-  n = get_normal_vector(model)
+  n = get_normal_vector(Triangulation(model))
   dt₁ = dt
   if leap_frog
     dt₁ = 2.0*dt
@@ -103,7 +103,7 @@ function shallow_water_rosenbrock_time_stepper(model, order, degree,
   ldiv!(H1MMchol, get_free_dof_values(f))
 
   # assemble the approximate MultiFieldFESpace Jacobian
-  n = get_normal_vector(model)
+  n = get_normal_vector(Ω)
 
   Amat((u,p),(v,q)) = ∫(-dt*λ*f*(v⋅⟂(u,n)))dΩ + ∫(dt*λ*g*(DIV(v)*p))dω - ∫(dt*λ*H₀*(q*DIV(u)))dω
   Mmat((u,p),(v,q)) = ∫(u⋅v)dΩ + ∫(p*q)dΩ # block mass matrix

--- a/src/ShallowWaterRosenbrock.jl
+++ b/src/ShallowWaterRosenbrock.jl
@@ -166,7 +166,7 @@ function shallow_water_rosenbrock_time_stepper(model, order, degree,
                                         RTMMchol, L2MMchol, A, Bchol, Blfchol, dt, τ, false)
 
     if (write_diagnostics && write_diagnostics_freq>0 && mod(istep, write_diagnostics_freq) == 0)
-      compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+      compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
       dump_diagnostics_shallow_water!(h_tmp, w_tmp,
                                       model, dΩ, dω, S, L2MM, H1MM,
                                       hn, un, wn, ϕ, F, g, istep, dt,
@@ -188,7 +188,7 @@ function shallow_water_rosenbrock_time_stepper(model, order, degree,
       #                 each iteration
       un, hn = yn
       if (write_diagnostics && write_diagnostics_freq>0 && mod(istep, write_diagnostics_freq) == 0)
-        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
         dump_diagnostics_shallow_water!(h_tmp, w_tmp,
                                         model, dΩ, dω, S, L2MM, H1MM,
                                         hn, un, wn, ϕ, F, g, istep, dt,
@@ -196,7 +196,7 @@ function shallow_water_rosenbrock_time_stepper(model, order, degree,
                                         dump_diagnostics_on_screen)
       end
       if (write_solution && write_solution_freq>0 && mod(istep, write_solution_freq) == 0)
-        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
         pvd[dt*Float64(istep)] = new_vtk_step(Ω,joinpath(output_dir,"n=$(istep)"),["hn"=>hn,"un"=>un,"wn"=>wn])
       end
     end

--- a/src/ShallowWaterThetaMethodFullNewton.jl
+++ b/src/ShallowWaterThetaMethodFullNewton.jl
@@ -25,7 +25,7 @@ function shallow_water_theta_method_full_newton_time_stepper(
       output_dir="nswe_ncells_$(num_cells(model))_order_$(order)_theta_method_full_newton")
 
   Ω  = Triangulation(model)
-  n  = get_normal_vector(model)
+  n  = get_normal_vector(Ω)
   dΩ = Measure(Ω,degree)
   dω = Measure(Ω,degree,ReferenceDomain())
 
@@ -97,7 +97,7 @@ function shallow_water_theta_method_full_newton_time_stepper(
          ∫(s*qvort*hiΔh + ⟂(∇(s),n)⋅uiΔu - s*fn +   # eq3
              v2⋅(F-hiΔh*uiΔu))dΩ                      # eq4
        end
-       
+
        # Solve fully-coupled monolithic nonlinear problem
        # Use previous time-step solution, ΔuΔhqF, as initial guess
        # Overwrite solution into ΔuΔhqF

--- a/src/ThermalShallowWaterExplicit.jl
+++ b/src/ThermalShallowWaterExplicit.jl
@@ -144,7 +144,7 @@ function thermal_shallow_water_explicit_time_stepper(model, order, degree,
     end
 
     if (write_diagnostics && write_diagnostics_freq==1)
-      compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+      compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
       dump_diagnostics_thermal_shallow_water!(h_tmp, w_tmp,
                                               model, dΩ, dω, S, L2MM, H1MM,
                                               hn, un, En, wn, ϕ, F, eF, 1, dt,
@@ -173,7 +173,7 @@ function thermal_shallow_water_explicit_time_stepper(model, order, degree,
                                                 RTMMchol, L2MMchol, dt, τ, true)
 
       if (write_diagnostics && write_diagnostics_freq>0 && mod(istep, write_diagnostics_freq) == 0)
-        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
         dump_diagnostics_thermal_shallow_water!(h_tmp, w_tmp,
                                                 model, dΩ, dω, S, L2MM, H1MM,
                                                 hn, un, En, wn, ϕ, F, eF, istep, dt,
@@ -181,7 +181,7 @@ function thermal_shallow_water_explicit_time_stepper(model, order, degree,
                                                 dump_diagnostics_on_screen)
       end
       if (write_solution && write_solution_freq>0 && mod(istep, write_solution_freq) == 0)
-        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(Ω))
 	pvd[dt*Float64(istep)] = new_vtk_step(Ω,joinpath(output_dir,"n=$(istep)"),["hn"=>hn,"un"=>un,"wn"=>wn,"en"=>e2])
       end
     end

--- a/src/ThermalShallowWaterExplicit.jl
+++ b/src/ThermalShallowWaterExplicit.jl
@@ -29,11 +29,11 @@ function thermal_shallow_water_explicit_time_step!(
      RTMMchol, L2MMchol, dt, τ, leap_frog)                            # more in args
 
   # energetically balanced explicit second order thermal shallow water solver.
-  # extends the explicit shallow water solver with the an additional buoyancy 
-  # modulated forcing term, and flux form equation for the density weighted 
+  # extends the explicit shallow water solver with the an additional buoyancy
+  # modulated forcing term, and flux form equation for the density weighted
   # buoyancy
 
-  n = get_normal_vector(model)
+  n = get_normal_vector(Triangulation(model))
   # explicit step for provisional velocity, uₚ
   dt1 = dt
   if leap_frog
@@ -95,7 +95,7 @@ function thermal_shallow_water_explicit_time_stepper(model, order, degree,
   H1MM, _, L2MM, H1MMchol, RTMMchol, L2MMchol = setup_and_factorize_mass_matrices(dΩ, R, S, U, V, P, Q)
 
   # Project the initial conditions onto the trial spaces
-  hn, un, f, hnv, unv, fv =  project_shallow_water_initial_conditions(dΩ, Q, V, S, 
+  hn, un, f, hnv, unv, fv =  project_shallow_water_initial_conditions(dΩ, Q, V, S,
                                L2MMchol, RTMMchol, H1MMchol, h₀, u₀, f₀)
 
   b₄(q)   = ∫(q*E₀)dΩ

--- a/test/WeakDivPerpTests.jl
+++ b/test/WeakDivPerpTests.jl
@@ -31,7 +31,7 @@ module WeakDivPerpTests
      # Setup geometry
      Ω=Triangulation(model)
      dΩ=Measure(Ω,degree)
-     n=get_normal_vector(model)
+     n=get_normal_vector(Ω)
 
      # Setup H(div) spaces
      reffe_rt = ReferenceFE(raviart_thomas, Float64, order)


### PR DESCRIPTION
In order to be consistent with Gridap (e.g., `get_facet_normal` is a method of `Triangulation`), and given that in Gridap 0.17 a triangulation is conceptually allowed to have access to the model, I have rewritten `get_normal_vector` such that it is now a method of the `CubedSphereTriangulation`s.