### PR TITLE
Thermal mat adv

### DIFF
--- a/driver/GalewskyThermalShallowWaterExplicit.jl
+++ b/driver/GalewskyThermalShallowWaterExplicit.jl
@@ -20,6 +20,16 @@ function gh₀(xyz)
   E
 end
 
+function g₀(xyz)
+  θϕr   = xyz2θϕr(xyz)
+  x,y,z = xyz
+  θ,ϕ,r = θϕr
+  α     = 1.0/3.0
+  β     = 1.0/10.0 #1.0/15.0
+  ϕ₂    = π/4
+  g + g*(200.0/H₀)*cos(ϕ)*exp(-1.0*(θ/α)*(θ/α))*exp(-1.0*((ϕ₂ - ϕ)/β)*((ϕ₂ - ϕ)/β))
+end
+
 order  = 1
 degree = 4
 
@@ -29,9 +39,9 @@ dt     = 60.0
 
 model = CubedSphereDiscreteModel(n; radius=rₑ)
 
-hf, uf = thermal_shallow_water_explicit_time_stepper(model, order, degree,
-                                    h₀, u₀, gh₀, f,
-                                    dt, 0.5*dt, nstep;
+hf, uf = thermal_shallow_water_mat_adv_explicit_time_stepper(model, order, degree,
+                                    h₀, u₀, g₀, f,
+                                    dt, 0.5*dt, 0.5*dt, nstep;
                                     write_solution=true,
                                     write_solution_freq=240,
                                     write_diagnostics=true,

--- a/driver/GeostrophicThermalShallowWaterExplicit.jl
+++ b/driver/GeostrophicThermalShallowWaterExplicit.jl
@@ -1,0 +1,29 @@
+module GeostrophicThermalShallowWaterExplicit
+
+using Gridap
+using GridapGeosciences
+
+include("ThermoGeostrophicInitialConditions.jl")
+
+# Thermogeostrophic configuration using the explicit thermal shallow water
+# solver.
+
+order  = 1
+degree = 4
+
+n      = 24
+nstep  = 20*24*30 # 20 days
+dt     = 120.0
+
+model = CubedSphereDiscreteModel(n; radius=rₑ)
+
+hf, uf = thermal_shallow_water_mat_adv_explicit_time_stepper(model, order, degree,
+                                    h₀, u₀, s₀, f,
+                                    dt, 0.5*dt, 0.0*dt, nstep;
+                                    write_solution=true,
+                                    write_solution_freq=360,
+                                    write_diagnostics=true,
+                                    write_diagnostics_freq=1,
+                                    dump_diagnostics_on_screen=true)
+
+end

--- a/driver/ThermoGeostrophicInitialConditions.jl
+++ b/driver/ThermoGeostrophicInitialConditions.jl
@@ -28,24 +28,7 @@ end
 function h₀(xyz)
   θϕr   = xyz2θϕr(xyz)
   θ,ϕ,r = θϕr
-  #h     = H₀
-  #ni    = 1000
-  #ϕₚ    = 0.0
-  #dϕ    = abs(ϕ/ni)
-  #sgn   = 1.0
-  #if ϕ < 0.0
-  #  sgn = -1.0
-  #end
-  #for i in 1:ni
-  #  ϕₚ   = ϕₚ + sgn*dϕ
-  #  _θϕr = VectorValue(θ,ϕₚ,r)
-  #  u    = uθ(_θϕr)
-  #  _f   = 2.0*Ωₑ*sin(ϕₚ)
-  #  h    = h - rₑ*u*(_f + tan(ϕₚ)*u/rₑ)*dϕ/g
-  #end
-  #h = -1.0*U₀*Ωₑ*xyz[3]*xyz[3]/rₑ/g + H₀
   h = havg(xyz)
-  #Rc = π/9.0
   Rc = π/8.0
   θc = -π/2.0 # mountain top longitude
   ϕc = +π/6.0 # mountain top latitude

--- a/driver/ThermoGeostrophicInitialConditions.jl
+++ b/driver/ThermoGeostrophicInitialConditions.jl
@@ -1,0 +1,76 @@
+# Initial conditions for thermogeostrophic balance for the thermal
+# shallow water equations. Adapted for the sphere from the planar
+# configuration in section 5.2 of:
+#     Eldred, Dubos and Kritsikis, JCP 379, 2018
+
+const H₀ = 5960.0
+const U₀ = 20.0
+const C₀ = 0.1
+
+function uθ(θϕr)
+  θ,ϕ,r = θϕr
+  u = U₀*cos(ϕ)
+  u
+end
+
+# Initial velocity
+function u₀(xyz)
+  θϕr = xyz2θϕr(xyz)
+  u   = uθ(θϕr)
+  spherical_to_cartesian_matrix(θϕr)⋅VectorValue(u,0,0)
+end
+
+function havg(xyz)
+  -1.0*U₀*Ωₑ*xyz[3]*xyz[3]/rₑ/g + H₀
+end
+
+# Initial fluid depth
+function h₀(xyz)
+  θϕr   = xyz2θϕr(xyz)
+  θ,ϕ,r = θϕr
+  #h     = H₀
+  #ni    = 1000
+  #ϕₚ    = 0.0
+  #dϕ    = abs(ϕ/ni)
+  #sgn   = 1.0
+  #if ϕ < 0.0
+  #  sgn = -1.0
+  #end
+  #for i in 1:ni
+  #  ϕₚ   = ϕₚ + sgn*dϕ
+  #  _θϕr = VectorValue(θ,ϕₚ,r)
+  #  u    = uθ(_θϕr)
+  #  _f   = 2.0*Ωₑ*sin(ϕₚ)
+  #  h    = h - rₑ*u*(_f + tan(ϕₚ)*u/rₑ)*dϕ/g
+  #end
+  #h = -1.0*U₀*Ωₑ*xyz[3]*xyz[3]/rₑ/g + H₀
+  h = havg(xyz)
+  #Rc = π/9.0
+  Rc = π/8.0
+  θc = -π/2.0 # mountain top longitude
+  ϕc = +π/6.0 # mountain top latitude
+  rc = sqrt((θ - θc)*(θ - θc) + (ϕ - ϕc)*(ϕ - ϕc))
+  if rc < Rc
+    h = h + 200.0*(1.0 - rc/Rc)
+  end
+  h
+end
+
+function s₀(xyz)
+  #h = h₀(xyz)
+  h = havg(xyz)
+  s = g*(1.0 + C₀*H₀*H₀/h/h)
+  s
+end
+
+function S₀(xyz)
+  h = h₀(xyz)
+  s = s₀(xyz)
+  S = s*h
+  S
+end
+
+# Topography
+function topography(xyz)
+  0.0
+end

--- a/src/DiagnosticTools.jl
+++ b/src/DiagnosticTools.jl
@@ -130,12 +130,41 @@ function dump_diagnostics_thermal_shallow_water!(h_tmp, w_tmp,
                 vorticity  = vort_i,
                 buoyancy   = buoy_i,
                 kinetic    = kin_i,
-                internal   = int_i,
+                potential  = pot_i,
                 power_k2p  = pow_k2p_i,
                 power_k2i  = pow_k2i_i)
 
   if dump_on_screen
     @printf("%5d %14.9e %14.9e %14.9e %14.9e %14.9e %14.9e %14.9e %14.9e\n",
-             step, mass_i, vort_i, buoy_i, kin_i, int_i, kin_i+int_i, pow_k2p_i, pow_k2i_i)
+             step, mass_i, vort_i, buoy_i, kin_i, pot_i, kin_i+pot_i, pow_k2p_i, pow_k2i_i)
+  end
+end
+
+function dump_diagnostics_thermal_shallow_water_mat_adv!(h_tmp, w_tmp,
+                                         model, dΩ, dω, S, L2MM, H1MM,
+                                         h, u, e, w, ϕ, F, de, step, dt,
+                                         output_file, dump_on_screen)
+
+  mass_i    = compute_total_mass!(h_tmp, L2MM, get_free_dof_values(h))
+  vort_i    = compute_total_mass!(w_tmp, H1MM, get_free_dof_values(w))
+  buoy_i    = sum(∫(h*e)dΩ)
+  kin_i     = Eₖ(u,h,dΩ)
+  pot_i     = Eₚ(h*h,e,0.5,dΩ)
+  pow_k2p_i = sum(∫(ϕ*DIV(F))dω)
+  pow_k2i_i = -0.5*sum(∫(F⋅de*h*h)dΩ)
+
+  append_to_csv(output_file;
+                time       = step*dt/24/60/60,
+                mass       = mass_i,
+                vorticity  = vort_i,
+                buoyancy   = buoy_i,
+                kinetic    = kin_i,
+                potential  = pot_i,
+                power_k2p  = pow_k2p_i,
+                power_k2i  = pow_k2i_i)
+
+  if dump_on_screen
+    @printf("%5d %14.9e %14.9e %14.9e %14.9e %14.9e %14.9e %14.9e %14.9e\n",
+             step, mass_i, vort_i, buoy_i, kin_i, pot_i, kin_i+pot_i, pow_k2p_i, pow_k2i_i)
   end
 end

--- a/src/GridapGeosciences.jl
+++ b/src/GridapGeosciences.jl
@@ -17,6 +17,7 @@ module GridapGeosciences
   include("ShallowWaterRosenbrock.jl")
   include("ShallowWaterIMEX.jl")
   include("ThermalShallowWaterExplicit.jl")
+  include("ThermalShallowWaterExplicit_MatAdv.jl")
   include("ShallowWaterThetaMethodFullNewton.jl")
   include("Helpers.jl")
   export rₑ, Ωₑ, g, f
@@ -39,6 +40,7 @@ module GridapGeosciences
   export shallow_water_rosenbrock_time_stepper
   export shallow_water_imex_time_stepper
   export thermal_shallow_water_explicit_time_stepper
+  export thermal_shallow_water_mat_adv_explicit_time_stepper
   export shallow_water_theta_method_full_newton_time_stepper
   export write_to_csv, get_scalar_field_from_csv, append_to_csv, initialize_csv
   export clone_fe_function, setup_mixed_spaces, setup_and_factorize_mass_matrices, new_vtk_step

--- a/src/ThermalShallowWaterExplicit_MatAdv.jl
+++ b/src/ThermalShallowWaterExplicit_MatAdv.jl
@@ -61,11 +61,11 @@ function thermal_shallow_water_mat_adv_explicit_time_step!(
   # 1.3: compute the temperature, dH/ds
   compute_temperature!(T,dΩ,S,H1MMchol,0.5*h₁*h₁)
   # 1.4: materially advected quantities (potential vorticity and buoyancy gradient)
-  compute_potential_vorticity!(q₁,H1h,H1hchol,dΩ,R,S,h₁,u₁,f,n)
+  compute_potential_vorticity!(q₁,H1h,H1hchol,dΩ,R,S,h₁,u₁,f,norm_vec)
   upwind_buoyancy!(e₁up,dΩ,S,H1MMchol,e₁,u₁,τₑ)
   compute_buoyancy_gradient!(de₁,dΩ,U,V,RTMMh,RTMMhchol,e₁up,h₁)
   # 1.5: solve for the provisional velocity
-  compute_velocity_tswe_mat_adv!(uₚ,dΩ,dω,V,RTMMchol,uₘ,q₁-τ*u₁⋅∇(q₁),de₁,F,ϕ,T,n,dt1,dt1)
+  compute_velocity_tswe_mat_adv!(uₚ,dΩ,dω,V,RTMMchol,uₘ,q₁-τ*u₁⋅∇(q₁),de₁,F,ϕ,T,norm_vec,dt1,dt1)
   # 1.6: solve for the provisional depth
   compute_depth!(hₚ,dΩ,dω,Q,L2MMchol,hₘ,F,dt1)
   # 1.7: solve for the buoyancy
@@ -79,11 +79,11 @@ function thermal_shallow_water_mat_adv_explicit_time_step!(
   # 2.3: compute the temperature, dH/ds
   compute_temperature!(T,dΩ,S,H1MMchol,(h₁*h₁+h₁*hₚ+hₚ*hₚ)/6.0)
   # 2.4: materially advected quantities (potential vorticity and buoyancy gradient)
-  compute_potential_vorticity!(q₂,H1h,H1hchol,dΩ,R,S,hₚ,uₚ,f,n)
+  compute_potential_vorticity!(q₂,H1h,H1hchol,dΩ,R,S,hₚ,uₚ,f,norm_vec)
   upwind_buoyancy!(e₂up,dΩ,S,H1MMchol,eₚ,uₚ,τₑ)
   compute_buoyancy_gradient!(de₂,dΩ,U,V,RTMMh,RTMMhchol,e₂up,hₚ)
   # 2.5: solve for the final velocity
-  compute_velocity_tswe_mat_adv!(u₂,dΩ,dω,V,RTMMchol,u₁,q₁-τ*u₁⋅∇(q₁)+q₂-τ*uₚ⋅∇(q₂),de₁+de₂,F,ϕ,T,n,0.5*dt,dt)
+  compute_velocity_tswe_mat_adv!(u₂,dΩ,dω,V,RTMMchol,u₁,q₁-τ*u₁⋅∇(q₁)+q₂-τ*uₚ⋅∇(q₂),de₁+de₂,F,ϕ,T,norm_vec,0.5*dt,dt)
   # 2.6: solve for the final depth
   compute_depth!(h₂,dΩ,dω,Q,L2MMchol,h₁,F,dt)
   # 2.7: solve for the buoyancy

--- a/src/ThermalShallowWaterExplicit_MatAdv.jl
+++ b/src/ThermalShallowWaterExplicit_MatAdv.jl
@@ -1,0 +1,236 @@
+function compute_temperature!(T,dΩ,S,H1MMchol,hh)
+  b(s) = ∫(s*hh)dΩ
+  Gridap.FESpaces.assemble_vector!(b, get_free_dof_values(T), S)
+  ldiv!(H1MMchol, get_free_dof_values(T))
+end
+
+# assume that H1chol factorization has already been performed
+function compute_buoyancy_gradient!(de,dΩ,U,V,RTMMh,RTMMhchol,e,h)
+  a(u,v) = ∫(v⋅u*h)dΩ
+  b(v)   = ∫(v⋅∇(e))dΩ
+  Gridap.FESpaces.assemble_matrix_and_vector!(a, b, RTMMh, get_free_dof_values(de), U, V)
+  lu!(RTMMhchol, RTMMh)
+  ldiv!(RTMMhchol, get_free_dof_values(de))
+end
+
+function compute_velocity_tswe_mat_adv!(u1,dΩ,dω,V,RTMMchol,u2,qAPVM,de,F,ϕ,T,n,dt1,dt2)
+  b(v) = ∫(v⋅u2 - dt1*(qAPVM)*(v⋅⟂(F,n)) + dt1*v⋅de*T)dΩ + ∫(dt2*DIV(v)*ϕ)dω
+  Gridap.FESpaces.assemble_vector!(b, get_free_dof_values(u1), V)
+  ldiv!(RTMMchol, get_free_dof_values(u1))
+end
+
+function compute_buoyancy!(e1,dΩ,S,H1MMchol,e2,de,F,dt)
+  b(s) = ∫(s*e2 - dt*s*de⋅F)dΩ
+  Gridap.FESpaces.assemble_vector!(b, get_free_dof_values(e1), S)
+  ldiv!(H1MMchol, get_free_dof_values(e1))
+end
+
+function upwind_buoyancy!(eup,dΩ,S,H1MMchol,e,u,τ)
+  b(s) = ∫(s*(e - τ*u⋅∇(e)))dΩ
+  Gridap.FESpaces.assemble_vector!(b, get_free_dof_values(eup), S)
+  ldiv!(H1MMchol, get_free_dof_values(eup))
+end
+
+function thermal_shallow_water_mat_adv_explicit_time_step!(
+     h₂, u₂, e₂, hₚ, uₚ, eₚ, ϕ, F, T, q₁, q₂, de₁, de₂, H1h, H1hchol,      # in/out args
+     model, dΩ, dω, U, V, Q, R, S, f, h₁, u₁, e₁, hₘ, uₘ, eₘ, e₁up, e₂up,  # in args
+     H1MMchol, RTMMchol, L2MMchol, RTMMh, RTMMhchol, dt, τ, τₑ, leap_frog) # more in args
+
+  # energetically balanced explicit second order thermal shallow water solver
+  #
+  # f          : coriolis force (field)
+  # h₁         : fluid depth at current time level
+  # u₁         : fluid velocity at current time level
+  # E₁         : fluid buoyancy at current time level
+  # RTMM       : H(div) mass matrix, ∫β⋅βdΩ, ∀β∈ H(div,Ω)
+  # L2MM       : L² mass matrix, ∫γγdΩ, ∀γ∈ L²(Ω)
+  # dt         : time step
+  # leap_frog  : do leap frog time integration for the first step (boolean)
+  # dΩ         : measure of the elements
+
+  n = get_normal_vector(model)
+  # explicit step for provisional velocity, uₚ
+  dt1 = dt
+  if leap_frog
+    dt1 = 2.0*dt
+  end
+
+  # 1.1: the mass flux, dH/du
+  compute_mass_flux!(F,dΩ,V,RTMMchol,u₁*h₁)
+  # 1.2: the bernoulli function, dH/dh
+  compute_bernoulli_potential!(ϕ,dΩ,Q,L2MMchol,u₁⋅u₁,h₁*e₁,1.0)
+  # 1.3: compute the temperature, dH/ds
+  compute_temperature!(T,dΩ,S,H1MMchol,0.5*h₁*h₁)
+  # 1.4: materially advected quantities (potential vorticity and buoyancy gradient)
+  compute_potential_vorticity!(q₁,H1h,H1hchol,dΩ,R,S,h₁,u₁,f,n)
+  upwind_buoyancy!(e₁up,dΩ,S,H1MMchol,e₁,u₁,τₑ)
+  compute_buoyancy_gradient!(de₁,dΩ,U,V,RTMMh,RTMMhchol,e₁up,h₁)
+  # 1.5: solve for the provisional velocity
+  compute_velocity_tswe_mat_adv!(uₚ,dΩ,dω,V,RTMMchol,uₘ,q₁-τ*u₁⋅∇(q₁),de₁,F,ϕ,T,n,dt1,dt1)
+  # 1.6: solve for the provisional depth
+  compute_depth!(hₚ,dΩ,dω,Q,L2MMchol,hₘ,F,dt1)
+  # 1.7: solve for the buoyancy
+  compute_buoyancy!(eₚ,dΩ,S,H1MMchol,eₘ,de₁,F,dt1)
+
+  # 2.1: the mass flux, dH/du
+  compute_mass_flux!(F,dΩ,V,RTMMchol,u₁*(2.0*h₁ + hₚ)/6.0+uₚ*(h₁ + 2.0*hₚ)/6.0)
+  # 2.2: the bernoulli function, dH/dh
+  compute_bernoulli_potential!(ϕ,dΩ,Q,L2MMchol,(u₁⋅u₁ + u₁⋅uₚ + uₚ⋅uₚ)/3.0,
+                               e₁*(2.0*h₁ + hₚ)/6.0+eₚ*(h₁ + 2.0*hₚ)/6.0,1.0)
+  # 2.3: compute the temperature, dH/ds
+  compute_temperature!(T,dΩ,S,H1MMchol,(h₁*h₁+h₁*hₚ+hₚ*hₚ)/6.0)
+  # 2.4: materially advected quantities (potential vorticity and buoyancy gradient)
+  compute_potential_vorticity!(q₂,H1h,H1hchol,dΩ,R,S,hₚ,uₚ,f,n)
+  upwind_buoyancy!(e₂up,dΩ,S,H1MMchol,eₚ,uₚ,τₑ)
+  compute_buoyancy_gradient!(de₂,dΩ,U,V,RTMMh,RTMMhchol,e₂up,hₚ)
+  # 2.5: solve for the final velocity
+  compute_velocity_tswe_mat_adv!(u₂,dΩ,dω,V,RTMMchol,u₁,q₁-τ*u₁⋅∇(q₁)+q₂-τ*uₚ⋅∇(q₂),de₁+de₂,F,ϕ,T,n,0.5*dt,dt)
+  # 2.6: solve for the final depth
+  compute_depth!(h₂,dΩ,dω,Q,L2MMchol,h₁,F,dt)
+  # 2.7: solve for the buoyancy
+  compute_buoyancy!(e₂,dΩ,S,H1MMchol,e₁,0.5*(de₁+de₂),F,dt)
+end
+
+function thermal_shallow_water_mat_adv_explicit_time_stepper(model, order, degree,
+                        h₀, u₀, e₀, f₀,
+                        dt, τ, τₑ, N;
+                        write_diagnostics=true,
+                        write_diagnostics_freq=1,
+                        dump_diagnostics_on_screen=true,
+                        write_solution=false,
+                        write_solution_freq=N/10,
+                        output_dir="tswe_ma_ncells_$(num_cells(model))_order_$(order)_explicit")
+
+  # Forward integration of the shallow water equations
+  Ω = Triangulation(model)
+  dΩ = Measure(Ω, degree)
+  dω = Measure(Ω, degree, ReferenceDomain())
+
+  # Setup the trial and test spaces
+  R, S, U, V, P, Q = setup_mixed_spaces(model, order)
+
+  # assemble the mass matrices
+  H1MM, RTMM, L2MM, H1MMchol, RTMMchol, L2MMchol = setup_and_factorize_mass_matrices(dΩ, R, S, U, V, P, Q)
+
+  # Project the initial conditions onto the trial spaces
+  b₁(q)   = ∫(q*h₀)dΩ
+  rhs1    = assemble_vector(b₁, Q)
+  hn      = FEFunction(Q, copy(rhs1))
+  ldiv!(L2MMchol, get_free_dof_values(hn))
+
+  b₂(v)   = ∫(v⋅u₀)dΩ
+  rhs2    = assemble_vector(b₂, V)
+  un      = FEFunction(V, copy(rhs2))
+  ldiv!(RTMMchol, get_free_dof_values(un))
+
+  b₃(s)   = ∫(s*f₀)*dΩ
+  rhs3    = assemble_vector(b₃, S)
+  f       = FEFunction(S, copy(rhs3))
+  ldiv!(H1MMchol, get_free_dof_values(f))
+
+  b₄(s)   = ∫(s*e₀)dΩ
+  rhs4    = assemble_vector(b₄, S)
+  en      = FEFunction(S, copy(rhs4))
+  ldiv!(H1MMchol, get_free_dof_values(en))
+
+  # work arrays
+  h_tmp = copy(get_free_dof_values(hn))
+  w_tmp = copy(get_free_dof_values(f))
+  # build the potential vorticity and buoyancy gradient lhs operator once just to initialise
+  bmm(a,b)  = ∫(a*hn*b)dΩ
+  H1h       = assemble_matrix(bmm, R, S)
+  H1hchol   = lu(H1h)
+  cmm(a,b)  = ∫(a⋅b*hn)dΩ
+  RTMMh     = assemble_matrix(cmm, U, V)
+  RTMMhchol = lu(RTMM)
+
+  function run_simulation(pvd=nothing)
+    diagnostics_file = joinpath(output_dir,"tswe_diagnostics.csv")
+
+    hm1    = clone_fe_function(Q,hn)
+    hm2    = clone_fe_function(Q,hn)
+    hp     = clone_fe_function(Q,hn)
+    ϕ      = clone_fe_function(Q,hn)
+    em1    = clone_fe_function(S,en)
+    em2    = clone_fe_function(S,en)
+    ep     = clone_fe_function(S,en)
+    e1up   = clone_fe_function(S,en)
+    e2up   = clone_fe_function(S,en)
+
+    um1    = clone_fe_function(V,un)
+    um2    = clone_fe_function(V,un)
+    up     = clone_fe_function(V,un)
+    F      = clone_fe_function(V,un)
+    eF     = clone_fe_function(V,un)
+
+    wn     = clone_fe_function(S,f)
+    T      = clone_fe_function(S,f)
+    q1     = clone_fe_function(S,f)
+    q2     = clone_fe_function(S,f)
+    de1    = clone_fe_function(V,un)
+    de2    = clone_fe_function(V,un)
+
+    # first step, no leap frog integration
+    thermal_shallow_water_mat_adv_explicit_time_step!(hn, un, en, hp, up, ep, ϕ, F, T, q1, q2, de1, de2, H1h, H1hchol,
+                                              model, dΩ, dω, U, V, Q, R, S, f, hm1, um1, em1, hm2, um2, em2, e1up, e2up,
+                                              H1MMchol, RTMMchol, L2MMchol, RTMMh, RTMMhchol, dt, τ, τₑ, false)
+
+    if (write_diagnostics)
+      initialize_csv(diagnostics_file,"time", "mass", "vorticity", "buoyancy", "kinetic", "internal", "power_k2p", "power_k2i")
+    end
+
+    if (write_diagnostics && write_diagnostics_freq==1)
+      compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+      dump_diagnostics_thermal_shallow_water_mat_adv!(h_tmp, w_tmp,
+                                              model, dΩ, dω, S, L2MM, H1MM,
+					      hn, un, en, wn, ϕ, F, 0.5*(de1+de2), 1, dt,
+                                              diagnostics_file,
+                                              dump_diagnostics_on_screen)
+    end
+
+    # subsequent steps, do leap frog integration
+    # (now that we have the state at two previous time levels)
+    for istep in 2:N
+      h_aux = hm2
+      hm2   = hm1
+      hm1   = hn
+      hn    = h_aux
+      u_aux = um2
+      um2   = um1
+      um1   = un
+      un    = u_aux
+      e_aux = em2
+      em2   = em1
+      em1   = en
+      en    = e_aux
+
+      thermal_shallow_water_mat_adv_explicit_time_step!(hn, un, en, hp, up, ep, ϕ, F, T, q1, q2, de1, de2, H1h, H1hchol,
+                                                model, dΩ, dω, U, V, Q, R, S, f, hm1, um1, em1, hm2, um2, em2, e1up, e2up,
+                                                H1MMchol, RTMMchol, L2MMchol, RTMMh, RTMMhchol, dt, τ, τₑ, true)
+
+      if (write_diagnostics && write_diagnostics_freq>0 && mod(istep, write_diagnostics_freq) == 0)
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+        dump_diagnostics_thermal_shallow_water_mat_adv!(h_tmp, w_tmp,
+                                                model, dΩ, dω, S, L2MM, H1MM,
+						hn, un, en, wn, ϕ, F, 0.5*(de1+de2), istep, dt,
+                                                diagnostics_file,
+                                                dump_diagnostics_on_screen)
+      end
+      if (write_solution && write_solution_freq>0 && mod(istep, write_solution_freq) == 0)
+        compute_diagnostic_vorticity!(wn, dΩ, S, H1MMchol, un, get_normal_vector(model))
+	pvd[dt*Float64(istep)] = new_vtk_step(Ω,joinpath(output_dir,"n=$(istep)"),["hn"=>hn,"un"=>un,"wn"=>wn,"en"=>en])
+      end
+    end
+    hn, un, en
+  end
+  if (write_diagnostics || write_solution)
+    rm(output_dir,force=true,recursive=true)
+    mkdir(output_dir)
+  end
+  if (write_solution)
+    pvdfile=joinpath(output_dir,"tswe_ma_ncells_$(num_cells(model))_order_$(order)_explicit")
+    paraview_collection(run_simulation,pvdfile)
+  else
+    run_simulation()
+  end
+end

--- a/src/ThermalShallowWaterExplicit_MatAdv.jl
+++ b/src/ThermalShallowWaterExplicit_MatAdv.jl
@@ -36,19 +36,6 @@ function thermal_shallow_water_mat_adv_explicit_time_step!(
      norm_vec, dΩ, dω, U, V, Q, R, S, f, h₁, u₁, e₁, hₘ, uₘ, eₘ, e₁up, e₂up, # in args
      H1MMchol, RTMMchol, L2MMchol, RTMMh, RTMMhchol, dt, τ, τₑ, leap_frog)   # more in args
 
-  # energetically balanced explicit second order thermal shallow water solver
-  #
-  # f          : coriolis force (field)
-  # h₁         : fluid depth at current time level
-  # u₁         : fluid velocity at current time level
-  # E₁         : fluid buoyancy at current time level
-  # RTMM       : H(div) mass matrix, ∫β⋅βdΩ, ∀β∈ H(div,Ω)
-  # L2MM       : L² mass matrix, ∫γγdΩ, ∀γ∈ L²(Ω)
-  # dt         : time step
-  # leap_frog  : do leap frog time integration for the first step (boolean)
-  # dΩ         : measure of the elements
-
-  # explicit step for provisional velocity, uₚ
   dt1 = dt
   if leap_frog
     dt1 = 2.0*dt


### PR DESCRIPTION
This involves the following changes:

1. A new solver for the thermal shallow water equations for which the buoyancy advection is in material form, with the buoyancy in the H1 conforming space (not L2). This seems to be more robust that the existing solver for the two tests that have been performed
2. A new "thermogeostrophic" configuration for the thermal shallow water equations. Basically a geostrophically balanced initial state with a thermally balanced state on top of that, and then a gaussian perturbation to the depth field in order to trigger some non-linearity around that state
3. A bug fix for the existing thermal SW diagnostics

In the next PR the upwinded trial funcs will be added, which will allow for additional high order energy consistent stabilisation of the potential vorticty and buoyancy fields.